### PR TITLE
Add fix for IE8 'html is undefined' error

### DIFF
--- a/js/vendor/css_browser_selector.js
+++ b/js/vendor/css_browser_selector.js
@@ -99,6 +99,10 @@ var uaInfo = {
 	}
 }
 
+if (typeof html =='undefined') { 
+	html=document.documentElement;
+}
+
 var screenInfo = {
 	width : (window.outerWidth || html.clientWidth) - 15,
 	height : window.outerHeight || html.clientHeight,


### PR DESCRIPTION
IE8 throws a console eror 'html is undefined' and this pull request adds in a catch for that to define it.  
