### PR TITLE
Added IE11+ compatibility

### DIFF
--- a/js/vendor/css_browser_selector.js
+++ b/js/vendor/css_browser_selector.js
@@ -41,6 +41,7 @@ var uaInfo = {
 
 		return [
 			(!(/opera|webtv/i.test(ua)) && /msie\s(\d+)/.test(ua)) ? ('ie ie' + (/trident\/4\.0/.test(ua) ? '8' : RegExp.$1))
+				:is('trident\/') ? 'ie ie'+ (/trident\/.+rv:(\d+)/i.test(ua) ? RegExp.$1 : '') //ie11+
 				:is('firefox/') ? g + " " + f + (/firefox\/((\d+)(\.(\d+))(\.\d+)*)/.test(ua) ? ' ' + f + RegExp.$2 + ' ' + f + RegExp.$2 + "_" + RegExp.$4 : '')
 				:is('gecko/') ? g
 				:is('opera') ? o + (/version\/((\d+)(\.(\d+))(\.\d+)*)/.test(ua) ? ' ' + o + RegExp.$2 + ' ' + o + RegExp.$2 + "_" + RegExp.$4 : (/opera(\s|\/)(\d+)\.(\d+)/.test(ua) ? ' ' + o + RegExp.$2 + " " + o + RegExp.$2 + "_" + RegExp.$3 : ''))


### PR DESCRIPTION
Since, as of Internet Explorer 11 has changed his user agent string, I added a new line that check it and adds `ie11` class to `<html>` tag.
