### PR TITLE
Fix Issue #14: Conflict with Modernizr - Save existing html classes

### DIFF
--- a/js/vendor/css_browser_selector.js
+++ b/js/vendor/css_browser_selector.js
@@ -224,7 +224,47 @@ function css_browser_selector(u, ns) {
 	b = b.concat(classesArray);
 
 	/* removendo itens invalidos do array */
+	/* add filter function polyfill for IE8 */
+	if (!Array.prototype.filter) {
+		Array.prototype.filter = function(fun/*, thisArg*/) {
+			'use strict';
+
+			if (this === void 0 || this === null) {
+				throw new TypeError();
+			}
+
+			var t = Object(this);
+			var len = t.length >>> 0;
+			if (typeof fun !== 'function') {
+				throw new TypeError();
+			}
+
+			var res = [];
+			var thisArg = arguments.length >= 2 ? arguments[1] : void 0;
+			for (var i = 0; i < len; i++) {
+				if (i in t) {
+					var val = t[i];
+
+					// NOTE: Technically this should Object.defineProperty at
+					//			 the next index, as push can be affected by
+					//			 properties on Object.prototype and Array.prototype.
+					//			 But that method's new, and collisions should be
+					//			 rare, so use the more-compatible alternative.
+					if (fun.call(thisArg, val, i, t)) {
+						res.push(val);
+					}
+				}
+			}
+
+			return res;
+		};
+	}
+
 	b = b.filter(function(e){
+		/* if no-js class exists, remove it */
+		if (e === 'no-js') {
+			return false;
+        }
 		return e;
 	});
 

--- a/js/vendor/css_browser_selector.js
+++ b/js/vendor/css_browser_selector.js
@@ -216,6 +216,13 @@ function css_browser_selector(u, ns) {
 	}
 
 
+	/* save & add existing html classes */
+	var classes = html.className;
+	var classesArray = classes.split(/ /);
+
+	/* merge existing classes on html tag */
+	b = b.concat(classesArray);
+
 	/* removendo itens invalidos do array */
 	b = b.filter(function(e){
 		return e;

--- a/tests/generator.js
+++ b/tests/generator.js
@@ -28,6 +28,7 @@ $(document).ready(function () {
 
     $.each(user_agent_strings,function(index, item) 
     	{
+		document.documentElement.className = '';
 		ua = item[0];
 		codes_expected = item[1];		
 		codes_returned = css_browser_selector(ua);


### PR DESCRIPTION
Save existing html classes, and merge it with CSSBS classes.
Add html classes reset in tests, to prevent increase classes between tests (because css_browser_selector now save current classes).
Thanks for @marcorieser
