### PR TITLE
Version 0.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,8 +75,8 @@
 
     <p>
         <strong>beta/experimental versions:</strong>
-        <br/>(https://github.com/ridjohansen/css_browser_selector/)
         <br/>(https://github.com/verbatim/css_browser_selector/)
+        <br/>(https://github.com/delka/css_browser_selector/)
     </p>
 </div>
 
@@ -87,23 +87,27 @@
 <h2 id="Identifies">Identifies</h2>
 <ul>
     <li>browsers: Firefox; IE; Opera; Safari; Chrome, Konqueror, Iron</li>
-    <li>browser versions: (most importantly: ie6, ie7, ie8, ie9)</li>
+    <li>browser versions: (most importantly: ie6, ie7, ie8, ie9, ie10, ie11, ie edge)</li>
     <li>rendering engines: Webkit; Mozilla; Gecko</li>
-    <li>platforms/OSes: Mac; Win: Win8, Win7, Vista, WinXP, Win2k, WinNT; FreeBSD; Linux/x11</li>
-    <li>devices: Ipod; Ipad; Iphone; WebTV; Blackberry; Android; J2me; RIM Playbook; mobile (generic)</li>
+    <li>platforms/OSes: Mac; Win: Win10, Win8.1, Win8, Win7, Vista, WinXP, Win2k, WinNT; FreeBSD; Linux/x11</li>
+    <li>devices: Ipod; Ipad; Iphone; WebTV; Blackberry; Android; Windows Phone, J2me; RIM Playbook; mobile (generic)</li>
     <li>enabled technology: JS (use in conjunction with &lt;html class="no-js"&gt; for even more granular
         control)
     </li>
     <li>language detection</li>
 </ul>
 
-<h4>Recent contributors to 0.5, 0.6, 0.7:</h4>
+<h4>Recent contributors to 0.5, 0.6, 0.7, 0.8:</h4>
 
 <ul>
     <li>
         <strong>improve and update features for cross-browser development</strong>
         <br/>https://github.com/ridjohansen/css_browser_selector/
     </li>
+    <li>
+        <strong>New Win OS, Browsers and WinPhone detection, save existing html classes:</strong>
+        <br/>https://github.com/delka/css_browser_selector/
+    </li>    
     <li>
         <strong>more detailed IE detection:</strong>
         <br/>https://github.com/kevingessner/css_browser_selector/
@@ -126,6 +130,18 @@
 
 <h4>Version History</h4>
 <ul>
+    <li>
+        <strong>v0.8 2015-10-29</strong>
+        <br/>Add support for Windows 8.1 and Windows 10
+        <br/>Add support for Windows Phone OS 7,8,10.
+        <br/>Add IE Edge Support
+        <br/>Save existing html classes
+        <br/>Prevent global variables - wrap code into anonymous function
+    </li> 
+    <li>
+        <strong>v0.71 2014-01-23</strong>
+        <br/>Add IE11 detection
+    </li>       
     <li>
         <strong>v0.7 2013-04-01</strong>
         <br/>Add support to Hi-dpi displays Selector

--- a/js/vendor/css_browser_selector.js
+++ b/js/vendor/css_browser_selector.js
@@ -224,7 +224,47 @@ function css_browser_selector(u, ns) {
 	b = b.concat(classesArray);
 
 	/* removendo itens invalidos do array */
+	/* add filter function polyfill for IE8 */
+	if (!Array.prototype.filter) {
+		Array.prototype.filter = function(fun/*, thisArg*/) {
+			'use strict';
+
+			if (this === void 0 || this === null) {
+				throw new TypeError();
+			}
+
+			var t = Object(this);
+			var len = t.length >>> 0;
+			if (typeof fun !== 'function') {
+				throw new TypeError();
+			}
+
+			var res = [];
+			var thisArg = arguments.length >= 2 ? arguments[1] : void 0;
+			for (var i = 0; i < len; i++) {
+				if (i in t) {
+					var val = t[i];
+
+					// NOTE: Technically this should Object.defineProperty at
+					//			 the next index, as push can be affected by
+					//			 properties on Object.prototype and Array.prototype.
+					//			 But that method's new, and collisions should be
+					//			 rare, so use the more-compatible alternative.
+					if (fun.call(thisArg, val, i, t)) {
+						res.push(val);
+					}
+				}
+			}
+
+			return res;
+		};
+	}
+
 	b = b.filter(function(e){
+		/* if no-js class exists, remove it */
+		if (e === 'no-js') {
+			return false;
+        }
 		return e;
 	});
 

--- a/js/vendor/css_browser_selector.js
+++ b/js/vendor/css_browser_selector.js
@@ -32,9 +32,6 @@ var uaInfo = {
 			f = 'firefox',
 			s = 'safari',
 			o = 'opera',
-			a = 'android',
-			bb = 'blackberry',
-			dv = 'device_',
 
 			ua = uaInfo.ua,
 			is = uaInfo.is;
@@ -46,8 +43,6 @@ var uaInfo = {
 				:is('gecko/') ? g
 				:is('opera') ? o + (/version\/((\d+)(\.(\d+))(\.\d+)*)/.test(ua) ? ' ' + o + RegExp.$2 + ' ' + o + RegExp.$2 + "_" + RegExp.$4 : (/opera(\s|\/)(\d+)\.(\d+)/.test(ua) ? ' ' + o + RegExp.$2 + " " + o + RegExp.$2 + "_" + RegExp.$3 : ''))
 				:is('konqueror') ? 'konqueror'
-				:is('blackberry') ? (bb + (/Version\/(\d+)(\.(\d+)+)/i.test(ua) ? " " + bb + RegExp.$1 + " " + bb + RegExp.$1 + RegExp.$2.replace('.', '_') : (/Blackberry ?(([0-9]+)([a-z]?))[\/|;]/gi.test(ua) ? ' ' + bb + RegExp.$2 + (RegExp.$3 ? ' ' + bb + RegExp.$2 + RegExp.$3 : '') : ''))) // blackberry
-				:is('android') ? (a + (/Version\/(\d+)(\.(\d+))+/i.test(ua) ? " " + a + RegExp.$1 + " " + a + RegExp.$1 + RegExp.$2.replace('.', '_') : '') + (/Android (.+); (.+) Build/i.test(ua) ? ' ' + dv + ((RegExp.$2).replace(/ /g, "_")).replace(/-/g, "_") : '')) //android
 				:is('chrome') ? w + ' ' + c + (/chrome\/((\d+)(\.(\d+))(\.\d+)*)/.test(ua) ? ' ' + c + RegExp.$2 + ((RegExp.$4 > 0) ? ' ' + c + RegExp.$2 + "_" + RegExp.$4 : '') : '')
 				:is('iron') ? w + ' iron'
 				:is('applewebkit/') ? (w + ' ' + s + (/version\/((\d+)(\.(\d+))(\.\d+)*)/.test(ua) ? ' ' + s + RegExp.$2 + " " + s + RegExp.$2 + RegExp.$3.replace('.', '_') : (/ Safari\/(\d+)/i.test(ua) ? ((RegExp.$1 == "419" || RegExp.$1 == "417" || RegExp.$1 == "416" || RegExp.$1 == "412") ? ' ' + s + '2_0' : RegExp.$1 == "312" ? ' ' + s + '1_3' : RegExp.$1 == "125" ? ' ' + s + '1_2' : RegExp.$1 == "85" ? ' ' + s + '1_0' : '') : ''))) //applewebkit
@@ -55,12 +50,20 @@ var uaInfo = {
 		];
 	},
 	getPlatform : function() {
-		var ua = uaInfo.ua,
+		var wp = 'winphone',
+			a  = 'android',
+			bb = 'blackberry',
+			dv = 'device_',
+
+			ua = uaInfo.ua,
 			version = uaInfo.version,
 			is = uaInfo.is;
 
 		return [
 			is('j2me') ? 'j2me'
+			:is('windows phone') ? (wp + (/Windows Phone (\d+)(\.(\d+))+/i.test(ua) ? " " + wp + RegExp.$1 + " " + wp + RegExp.$1 + RegExp.$2.replace('.', '_') : (/Windows Phone OS (\d+)(\.(\d+))+/i.test(ua) ? " " + wp + RegExp.$1 + " " + wp + RegExp.$1 + RegExp.$2.replace('.', '_') : ''))) // Windows Phone
+			:is('blackberry') ? (bb + (/Version\/(\d+)(\.(\d+)+)/i.test(ua) ? " " + bb + RegExp.$1 + " " + bb + RegExp.$1 + RegExp.$2.replace('.', '_') : (/Blackberry ?(([0-9]+)([a-z]?))[\/|;]/gi.test(ua) ? ' ' + bb + RegExp.$2 + (RegExp.$3 ? ' ' + bb + RegExp.$2 + RegExp.$3 : '') : ''))) // blackberry
+			:is('android') ? (a + (/Version\/(\d+)(\.(\d+))+/i.test(ua) ? " " + a + RegExp.$1 + " " + a + RegExp.$1 + RegExp.$2.replace('.', '_') : '') + (/Android (.+); (.+) Build/i.test(ua) ? ' ' + dv + ((RegExp.$2).replace(/ /g, "_")).replace(/-/g, "_") : '')) //android
 			:is('ipad|ipod|iphone') ? (
 			(/CPU( iPhone)? OS (\d+[_|\.]\d+([_|\.]\d+)*)/i.test(ua) ? 'ios' + version('ios', RegExp.$2) : '') + ' ' + (/(ip(ad|od|hone))/gi.test(ua) ? RegExp.$1 : "")) //'iphone'
 			//:is('ipod')?'ipod'
@@ -82,7 +85,7 @@ var uaInfo = {
 	getMobile : function() {
 		var is = uaInfo.is;
 		return [
-			is("android|mobi|mobile|j2me|iphone|ipod|ipad|blackberry|playbook|kindle|silk") ? 'mobile' : ''
+			is("android|mobi|mobile|j2me|iphone|ipod|ipad|blackberry|winphone|playbook|kindle|silk") ? 'mobile' : ''
 		];
 	},
 	getIpadApp : function() {

--- a/js/vendor/css_browser_selector.js
+++ b/js/vendor/css_browser_selector.js
@@ -35,7 +35,6 @@ var uaInfo = {
 			a = 'android',
 			bb = 'blackberry',
 			dv = 'device_',
-			v = 0,
 
 			ua = uaInfo.ua,
 			is = uaInfo.is;

--- a/js/vendor/css_browser_selector.js
+++ b/js/vendor/css_browser_selector.js
@@ -216,6 +216,13 @@ function css_browser_selector(u, ns) {
 	}
 
 
+	/* save & add existing html classes */
+	var classes = html.className;
+	var classesArray = classes.split(/ /);
+
+	/* merge existing classes on html tag */
+	b = b.concat(classesArray);
+
 	/* removendo itens invalidos do array */
 	b = b.filter(function(e){
 		return e;

--- a/js/vendor/css_browser_selector.js
+++ b/js/vendor/css_browser_selector.js
@@ -1,5 +1,5 @@
 /*
- CSS Browser Selector 1.0
+ CSS Browser Selector 0.8
  Originally written by Rafael Lima (http://rafael.adm.br)
  http://rafael.adm.br/css_browser_selector
  License: http://creativecommons.org/licenses/by/2.5/
@@ -7,7 +7,7 @@
  Co-maintained by:
  https://github.com/ridjohansen/css_browser_selector
  https://github.com/wbruno/css_browser_selector
-
+ https://github.com/delka/css_browser_selector
  */
 (function() {
 var uaInfo = {

--- a/js/vendor/css_browser_selector.js
+++ b/js/vendor/css_browser_selector.js
@@ -35,12 +35,14 @@ var uaInfo = {
 			a = 'android',
 			bb = 'blackberry',
 			dv = 'device_',
+			v = 0,
 
 			ua = uaInfo.ua,
 			is = uaInfo.is;
 
 		return [
 			(!(/opera|webtv/i.test(ua)) && /msie\s(\d+)/.test(ua)) ? ('ie ie' + (/trident\/4\.0/.test(ua) ? '8' : RegExp.$1))
+				:is('edge\/') ? 'edge ie' + (/edge\/(\d+)\.(\d+)/.test(ua) ? RegExp.$1 + ' ie' + RegExp.$1 + '_' + RegExp.$2 : '') // IE Edge
 				:is('trident\/') ? 'ie ie'+ (/trident\/.+rv:(\d+)/i.test(ua) ? RegExp.$1 : '') //ie11+
 				:is('firefox/') ? g + " " + f + (/firefox\/((\d+)(\.(\d+))(\.\d+)*)/.test(ua) ? ' ' + f + RegExp.$2 + ' ' + f + RegExp.$2 + "_" + RegExp.$4 : '')
 				:is('gecko/') ? g

--- a/js/vendor/css_browser_selector.js
+++ b/js/vendor/css_browser_selector.js
@@ -69,7 +69,9 @@ var uaInfo = {
 			:is('kindle|silk') ? 'kindle'
 			:is('playbook') ? 'playbook'
 			:is('mac') ? 'mac' + (/mac os x ((\d+)[.|_](\d+))/.test(ua) ? (' mac' + (RegExp.$2) + ' mac' + (RegExp.$1).replace('.', "_")) : '')
-			:is('win') ? 'win' + (is('windows nt 6.2') ? ' win8'
+			:is('win') ? 'win' + (is('windows nt 10.0') ? ' win10'
+			:is('windows nt 6.3') ? ' win8_1'
+			:is('windows nt 6.2') ? ' win8'
 			:is('windows nt 6.1') ? ' win7'
 			:is('windows nt 6.0') ? ' vista'
 			:is('windows nt 5.2') || is('windows nt 5.1') ? ' win_xp'

--- a/tests/generator.js
+++ b/tests/generator.js
@@ -28,6 +28,7 @@ $(document).ready(function () {
 
     $.each(user_agent_strings,function(index, item) 
     	{
+		document.documentElement.className = '';
 		ua = item[0];
 		codes_expected = item[1];		
 		codes_returned = css_browser_selector(ua);


### PR DESCRIPTION
Combine Pull Requests #17, #18, #19, #20 and #21 into one new version of „CSS Browser Selector +“.
Update Readme, Version history and plugin version number in `css_browser_selector.js`
- Add support for Windows 8.1 and Windows 10
- Add support for Windows Phone OS 7,8,10.
- Add IE Edge Support
- Save existing html classes
- Prevent global variables - wrap code into anonymous function

Download link: [CSS Browser Selector + v0.8](https://github.com/delka/css_browser_selector/releases/tag/v0.8)
